### PR TITLE
Load css after parent template

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -4,8 +4,10 @@
  * Additional code for the child theme goes in here.
  */
 
-add_action( 'wp_enqueue_scripts', 'enqueue_child_styles');
+add_action( 'wp_enqueue_scripts', 'enqueue_child_styles', 99);
 
 function enqueue_child_styles() {
-	wp_enqueue_style( 'child-style', get_stylesheet_directory_uri() . '/style.css' );
+	$css_creation = filectime(get_stylesheet_directory() . '/style.css');
+
+	wp_enqueue_style( 'child-style', get_stylesheet_directory_uri() . '/style.css', [], $css_creation );
 }


### PR DESCRIPTION
Add a precedence high number to make sure that child-theme css is loaded after the parent. This way we can override existing classes.

It also adds a version tag to avoid cache issues.